### PR TITLE
Add email whitelist to the server to avoid external intruders

### DIFF
--- a/server/config/passport.mjs
+++ b/server/config/passport.mjs
@@ -2,6 +2,7 @@ import passport from "passport";
 import { OAuth2Strategy as GoogleStrategy } from "passport-google-oauth";
 import User from "../models/users.mjs";
 import { Strategy as JWTStrategy, ExtractJwt } from "passport-jwt";
+import EmailWhitelist from "../models/emailWhitelist.mjs";
 
 passport.serializeUser(function (user, done) {
     done(null, user);
@@ -19,6 +20,12 @@ passport.use(
             callbackURL: "http://localhost:5050/auth/google/callback"
         },
         async function (accessToken, refreshToken, profile, done) {
+            const validEmail = await EmailWhitelist.findOne({ email: profile.emails[0].value });
+
+            if (!validEmail) {
+                done(null, null);
+            }
+
             let user = await User.findOne({ externalId: profile.id });
 
             if (!user) {

--- a/server/models/emailWhitelist.mjs
+++ b/server/models/emailWhitelist.mjs
@@ -1,0 +1,8 @@
+import { Schema, model } from "mongoose";
+
+const emailWhitelist = new Schema({
+    email: String
+});
+
+const EmailWhitelist = model("EmailWhitelist", emailWhitelist);
+export default EmailWhitelist;

--- a/server/routes/auth.mjs
+++ b/server/routes/auth.mjs
@@ -11,7 +11,7 @@ router.get(
 
 router.get(
     "/google/callback",
-    passport.authenticate("google", { failureRedirect: "/login", session: false }),
+    passport.authenticate("google", { failureRedirect: "http://localhost:3000/login", session: false }),
     function (req, res) {
         if (req.user) {
             const token = jwt.sign({ id: req.user._id }, "top_secret", {

--- a/server/routes/emailWhitelist.mjs
+++ b/server/routes/emailWhitelist.mjs
@@ -1,0 +1,46 @@
+import { Router as expressRouter } from "express";
+import EmailWhitelist from "../models/emailWhitelist.mjs";
+
+const router = expressRouter();
+
+router.get("/", async (req, res) => {
+    const results = await EmailWhitelist.find();
+    res.send(results).status(200);
+});
+
+router.get("/:id", async (req, res) => {
+    const result = await EmailWhitelist.findById(req.params.id);
+
+    if (!result) res.send("Not found").status(404);
+    else res.send(result).status(200);
+});
+
+router.post("/", async (req, res) => {
+    const newEmail = new EmailWhitelist({
+        email: req.body.email
+    });
+    const result = await newEmail.save();
+    res.send(result).status(204);
+});
+
+router.patch("/:id", async (req, res) => {
+    const emailToUpdate = await EmailWhitelist.findById(req.params.id);
+
+    emailToUpdate.set({
+        name: req.body.name,
+        position: req.body.position,
+        level: req.body.level
+    });
+
+    const result = await emailToUpdate.save();
+
+    res.send(result).status(200);
+});
+
+router.delete("/:id", async (req, res) => {
+    const result = await EmailWhitelist.findByIdAndDelete(req.params.id);
+
+    res.send(result).status(200);
+});
+
+export default router;

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -9,6 +9,7 @@ import session from "express-session";
 import record from "./routes/record.mjs";
 import user from "./routes/user.mjs";
 import auth from "./routes/auth.mjs";
+import emailWhitelist from "./router/emailWhitelist.mjs";
 
 const PORT = process.env.PORT || 5050;
 const app = express();
@@ -26,6 +27,7 @@ app.use(session({
 
 app.use("/record", passport.authenticate("jwt"),  record);
 app.use("/user", passport.authenticate("jwt"),  user);
+app.use("/emailWhitelist", passport.authenticate("jwt"),  emailWhitelist);
 app.use("/auth", auth);
 
 // start the Express server


### PR DESCRIPTION
This adds the EmailWhitelist model and routes to enable the option to add emails and remove them. In the future we will have to add a role system where only the admins can change this list, but that will be another PR.

The list of emails prevents an external user from logging in to the app if their google email is not registered in the whitelist table.